### PR TITLE
Update TV Shows.yml

### DIFF
--- a/JJJonesJr33/TV Shows.yml
+++ b/JJJonesJr33/TV Shows.yml
@@ -34,7 +34,7 @@ collections:
   Apple+:
     template: { name: network, network: 2552, poster: https://theposterdb.com/api/assets/168823}
   Amazon:
-    template: { name: network, network: 1024, poster:https://theposterdb.com/api/assets/90886}
+    template: { name: network, network: 1024, poster: https://theposterdb.com/api/assets/90886}
   AMC:
     template: { name: network, network: "174, 4661", poster: https://theposterdb.com/api/assets/104445}
   Cartoon Network:


### PR DESCRIPTION
missing space for Amazon network poster. Causing failure to retrieve poster.