### PR TITLE
meisnate12/MovieCharts: Add Rotten Tomatoes Best of 2022 list

### DIFF
--- a/meisnate12/MovieCharts.yml
+++ b/meisnate12/MovieCharts.yml
@@ -62,3 +62,5 @@ collections:
     template: { name: Best of, year: 2020 }
   Best of 2021:
     template: { name: Best of, year: 2021 }
+  Best of 2022:
+    template: { name: Best of, year: 2022 }


### PR DESCRIPTION
This PR
* Adds a new collection for the 2022 best of Rotten Tomatoes list (tracked via https://trakt.tv/users/lish408/lists/rotten-tomatoes-best-of-2022). This is similar to previous years