### PR TITLE
Add radarr_add_missing to chart_shared template

### DIFF
--- a/PMM/chart/imdb.yml
+++ b/PMM/chart/imdb.yml
@@ -13,38 +13,29 @@
 #          # Sets the value at the start of the sort title  #
 #          collection_section: "01"                         #
 #                                                           #
-#          # Turn the IMDb Popular collection on/off        #
-#          use_popular: true                                #
-#          # Determines collection order in it's section    #
-#          order_popular:                                   #
-#          # Set visible_library for IMDb Popular           #
-#          visible_library_popular:                         #
-#          # Set visible_home for IMDb Popular              #
-#          visible_home_popular:                            #
-#          # Set visible_shared for IMDb Popular            #
-#          visible_shared_popular:                          #
+#          # For each collection use the "key" to set       #
+#          # the options.                                   #
+#          # Available collections                          #
+#          #   KEY              COLLECTION                  #
+#          #   popular          IMDb Popular                #
+#          #   top              IMDb Top 250                #
+#          #   lowest           IMDb Lowest                 #
 #                                                           #
-#          # Turn the IMDb Top 250 collection on/off        #
-#          use_top: true                                    #
-#          # Determines collection order in it's section    #
-#          order_top:                                       #
-#          # Set visible_library for IMDb Top 250           #
-#          visible_library_top:                             #
-#          # Set visible_home for IMDb Top 250              #
-#          visible_home_top:                                #
-#          # Set visible_shared for IMDb Top 250            #
-#          visible_shared_top:                              #
+#          # Available options. Replace "key"               #
+#          # with desired collection.                       #
 #                                                           #
-#          # Turn the IMDb Lowest collection on/off         #
-#          use_lowest: true                                 #
-#          # Determines collection order in it's section    #
-#          order_trending:                                  #
-#          # Set visible_library for IMDb Lowest            #
-#          visible_library_lowest:                          #
-#          # Set visible_home for IMDb Lowest               #
-#          visible_home_lowest:                             #
-#          # Set visible_shared for IMDb Lowest             #
-#          visible_shared_lowest:                           #
+#          # Turn the collection on/off                     #
+#          use_key: true                                    #
+#          # Set visible_library for collection             #
+#          visible_library_key                              #
+#          # Set visible_home for collection                #
+#          visible_home_key:                                #
+#          # Set visible_shared for collection              #
+#          visible_shared_key:                              #
+#          # Add missing to rdarr                           #
+#          radarr_add_missing_key:                          #
+#          # Set tag for radarr                             #
+#          radarr_tag_key:                                  #
 #############################################################
 
 external_templates:

--- a/PMM/templates.yml
+++ b/PMM/templates.yml
@@ -60,10 +60,10 @@ templates:
       - visible_home_<<key>>
       - visible_shared_<<key>>
       - collection_mode
-      - radarr_add_missing
-      - sonarr_add_missing
-      - radarr_tag
-      - sonarr_tag
+      - radarr_add_missing_<<key>>
+      - sonarr_add_missing_<<key>>
+      - radarr_tag_<<key>>
+      - sonarr_tag_<<key>>
       - item_radarr_tag
       - item_sonarr_tag
       - library_types
@@ -74,10 +74,10 @@ templates:
     visible_library: <<visible_library_<<key>>>>
     visible_home: <<visible_home_<<key>>>>
     visible_shared: <<visible_shared_<<key>>>>
-    radarr_add_missing: <<radarr_add_missing>>
-    sonarr_add_missing: <<sonarr_add_missing>>
-    radarr_tag: <<radarr_tag>>
-    sonarr_tag: <<sonarr_tag>>
+    radarr_add_missing: <<radarr_add_missing_<<key>>>>
+    sonarr_add_missing: <<sonarr_add_missing_<<key>>>>
+    radarr_tag: <<radarr_tag_<<key>>>>
+    sonarr_tag: <<sonarr_tag_<<key>>>>
     item_radarr_tag: <<item_radarr_tag>>
     item_sonarr_tag: <<item_sonarr_tag>>
     collection_mode: <<collection_mode>>


### PR DESCRIPTION
## Checklist

-  I did not edit my own config files. Instead just opening this as a discussion point around template variables for radarr_add_missing_key in the chart_shared template. 
-  I didn't upload any poster or background images to the repository
