### PR TITLE
Better recognizing IMAX-E

### DIFF
--- a/PMM/overlays/special_release.yml
+++ b/PMM/overlays/special_release.yml
@@ -138,7 +138,7 @@ overlays:
         slug: enhanced
     plex_all: true
     filters:
-      filepath.regex: '(?i)\bIMAX Enhanced\b'
+      filepath.regex: '(?i)\bIMAX Enhanced\b|^(?=.*(DSNP|Disney\+|CORE(?=[ ._-]web[ ._-]?(dl|rip)\b)|\bBC(?=[ ._-]web[ ._-]?(dl|rip)\b)|IMAX[- .]Enhanced)\b)(?=.*\b(IMAX|IMAX[- .]Enhanced)\b).*'
 
   IMAX:
     template:


### PR DESCRIPTION
Better recognizing if you use `Original Title` or `Original Filename` as naming scheme.
Credits: Alex

## Checklist

- [x] I only edited my own config files.
- [x] I didn't upload any poster or background images to the repository
