### PR TITLE
Fixed DTS-X copy/paste error

### DIFF
--- a/PMM/overlays/audio_codec.yml
+++ b/PMM/overlays/audio_codec.yml
@@ -239,7 +239,7 @@ overlays:
         slug: x
     plex_all: true
     filters:
-      audio_track_title.regex: '(?i)dts[ ._:-]?x(?!\\d)'
+      audio_track_title.regex: '(?i)dts[-. ]?x(?!\d)'
 
   DTS-X-Filepath:
     template:
@@ -249,4 +249,4 @@ overlays:
         slug: x
     plex_all: true
     filters:
-      filepath.regex: '(?i)dts[ ._:-]?x(?!\\d)'
+      filepath.regex: '(?i)dts[-. ]?x(?!\d)'


### PR DESCRIPTION
- Fixed: `DTS-X` copy/paste error taken from the json - json needs to have a extra `\` before a special character.

## Checklist

- [x] I only edited my own config files.
- [x] I didn't upload any poster or background images to the repository
