### PR TITLE
complete overhaul of the audio codec

### DIFF
--- a/PMM/overlays/audio_codec.yml
+++ b/PMM/overlays/audio_codec.yml
@@ -71,7 +71,7 @@ overlays:
   Opus:
     template:
       - name: AudioCodec
-        weight: 5
+        weight: 250
         slug: opus
     plex_all: true
     filters:
@@ -81,39 +81,77 @@ overlays:
     template:
       - name: AudioCodec
         overlay: Opus
-        weight: 5
+        weight: 250
         slug: opus
     plex_all: true
     filters:
       filepath.regex: '(?i)\bOPUS(\b|\d)'
 
+# Placeholder no image yet or planned.
+  MP3:
+    template:
+      - name: AudioCodec
+        weight: 500
+        slug: mp3
+    plex_all: true
+    filters:
+      audio_track_title.regex: '(?i)\bmp3(\b|\d)'
+
+  MP3-Filepath:
+    template:
+      - name: AudioCodec
+        overlay: mp3
+        weight: 500
+        slug: mp3
+    plex_all: true
+    filters:
+      filepath.regex: '(?i)\bmp3(\b|\d)'
+
   Dolby-Digital:
     template:
       - name: AudioCodec
-        weight: 10
+        weight: 750
         slug: digital
     plex_all: true
     filters:
       audio_track_title.regex:
         - '(?i)\bDD[^a-z+]|(?<!e)ac3'
-        - '(?i)\bAAC \b[s5]?'
 
   Dolby-Digital-Filepath:
     template:
       - name: AudioCodec
         overlay: Dolby-Digital
-        weight: 10
+        weight: 750
         slug: digital
     plex_all: true
     filters:
       filepath.regex:
         - '(?i)\bDD[^a-z+]|(?<!e)ac3'
-        - '(?i)\bAAC \b[s5]?'
+
+# Placeholder no image yet or planned.
+  AAC:
+    template:
+      - name: AudioCodec
+        weight: 1000
+        slug: aac
+    plex_all: true
+    filters:
+      audio_track_title.regex: '(?i)\bAAC(\b|\d)'
+
+  AAC-Filepath:
+    template:
+      - name: AudioCodec
+        overlay: AAC
+        weight: 1000
+        slug: aac
+    plex_all: true
+    filters:
+      filepath.regex: '(?i)\bAAC(\b|\d)'
 
   DTS:
     template:
       - name: AudioCodec
-        weight: 20
+        weight: 1250
         slug: dts
     plex_all: true
     filters:
@@ -123,7 +161,7 @@ overlays:
     template:
       - name: AudioCodec
         overlay: DTS
-        weight: 20
+        weight: 1250
         slug: dts
     plex_all: true
     filters:
@@ -132,26 +170,88 @@ overlays:
   DTS-ES:
     template:
       - name: AudioCodec
-        weight: 30
+        weight: 1500
         slug: es
     plex_all: true
     filters:
-      audio_track_title.regex: '(?i)dts[-. ]?es\b'
+      audio_track_title.regex: 'dts[-. ]?es\b'
 
   DTS-ES-Filepath:
     template:
       - name: AudioCodec
         overlay: DTS-ES
-        weight: 30
+        weight: 1500
         slug: es
     plex_all: true
     filters:
       filepath.regex: '(?i)dts[-. ]?es\b'
 
+# Match DD+/E-AC3 without Atmos
+  Dolby-Digital-Plus:
+    template:
+      - name: AudioCodec
+        weight: 1750
+        slug: plus
+    plex_all: true
+    filters:
+      audio_track_title.regex:
+        - '(?i)^(?!.*(atmos))(?=.*\b([^-]DD[P+](?!A)|eac3)\b).*'
+
+  Dolby-Digital-Plus-Filepath:
+    template:
+      - name: AudioCodec
+        overlay: Dolby-Digital-Plus
+        weight: 1750
+        slug: plus
+    plex_all: true
+    filters:
+      filepath.regex:
+        - '(?i)^(?!.*(atmos))(?=.*\b([^-]DD[P+](?!A)|eac3)\b).*'
+
+# Placeholder no image yet or planned.
+  PCM:
+    template:
+      - name: AudioCodec
+        weight: 2000
+        slug: pcm
+    plex_all: true
+    filters:
+      audio_track_title.regex: '(?i)\b(l?)PCM(\b|\d)'
+
+  PCM-Filepath:
+    template:
+      - name: AudioCodec
+        overlay: pcm
+        weight: 2000
+        slug: pcm
+    plex_all: true
+    filters:
+      filepath.regex: '(?i)\b(l?)PCM(\b|\d)'
+
+# Placeholder no image yet or planned.
+  FLAC:
+    template:
+      - name: AudioCodec
+        weight: 2000
+        slug: flac
+    plex_all: true
+    filters:
+      audio_track_title.regex: '(?i)\bFLAC(\b|\d)'
+
+  FLAC-Filepath:
+    template:
+      - name: AudioCodec
+        overlay: flac
+        weight: 2000
+        slug: flac
+    plex_all: true
+    filters:
+      filepath.regex: '(?i)\bFLAC(\b|\d)'
+
   DTS-HD:
     template:
       - name: AudioCodec
-        weight: 40
+        weight: 2500
         slug: hd
     plex_all: true
     filters:
@@ -163,7 +263,7 @@ overlays:
     template:
       - name: AudioCodec
         overlay: DTS-HD
-        weight: 40
+        weight: 2500
         slug: hd
     plex_all: true
     filters:
@@ -171,82 +271,104 @@ overlays:
         - '(?i)dts[ .-]?(ma\b|hd[ .-]?ma|hd)(?!china|r)'
         - '(?i)dts[ ._-]?(hd[. ]?)?(hr|hi)'
 
+# Match TrueHD without Atmos
   Dolby-TrueHD:
     template:
       - name: AudioCodec
-        weight: 50
+        weight: 2750
         slug: truehd
     plex_all: true
     filters:
-      audio_track_title.regex: '(?i)true[ .-]?hd'
+      audio_track_title.regex: '(?i)^(?!.*(atmos))(?=.*\b(true[ .-]?hd)\b).*'
 
   Dolby-TrueHD-Filepath:
     template:
       - name: AudioCodec
         overlay: Dolby-TrueHD
-        weight: 50
+        weight: 2750
         slug: truehd
     plex_all: true
     filters:
-      filepath.regex: '(?i)true[ .-]?hd'
+      filepath.regex: '(?i)^(?!.*(atmos))(?=.*\b(true[ .-]?hd)\b).*'
 
-  Dolby-Digital-Plus:
+# Match DD+/E-AC3 Atmos
+  Dolby-Digital-Plus-Atmos:
     template:
       - name: AudioCodec
-        weight: 60
-        slug: plus
+        weight: 3000
+        slug: plus-atmos
     plex_all: true
     filters:
       audio_track_title.regex:
         - '(?i)[^-]DD[P+](?!A)|eac3'
-        - '(?i)\bAAC 7\b'
 
-  Dolby-Digital-Plus-Filepath:
+  Dolby-Digital-Plus-Atmos-Filepath:
     template:
       - name: AudioCodec
         overlay: Dolby-Digital-Plus
-        weight: 60
-        slug: plus
+        weight: 3000
+        slug: plus-atmos
     plex_all: true
     filters:
       filepath.regex:
         - '(?i)[^-]DD[P+](?!A)|eac3'
-        - '(?i)\bAAC 7\b'
 
+# Match ATMOS (undefined), meaning it doesn't know the base audio DD+ or TrueHD
   Dolby-Atmos:
     template:
       - name: AudioCodec
-        weight: 70
+        weight: 3000
         slug: atmos
     plex_all: true
     filters:
-      audio_track_title.regex: '(?i)atmos'
+      audio_track_title.regex: '(?i)^(?!.*([^-]DD[P+](?!A)|eac3|true[ .-]?hd))(?=.*\b(atmos(\b|\d))).*'
 
   Dolby-Atmos-Filepath:
     template:
       - name: AudioCodec
         overlay: Dolby-Atmos
-        weight: 70
+        weight: 3000
         slug: atmos
     plex_all: true
     filters:
-      filepath.regex: '(?i)atmos'
+      filepath.regex:
+        - '(?i)^(?!.*([^-]DD[P+](?!A)|eac3|true[ .-]?hd))(?=.*\b(atmos(\b|\d))).*'
 
   DTS-X:
     template:
       - name: AudioCodec
-        weight: 80
+        weight: 4500
         slug: x
     plex_all: true
     filters:
-      audio_track_title.regex: '(?i)dts[-. ]?x(?!\d)'
+      audio_track_title.regex: 'dts[-. ]?x(?!\d)'
 
   DTS-X-Filepath:
     template:
       - name: AudioCodec
         overlay: DTS-X
-        weight: 80
+        weight: 4500
         slug: x
     plex_all: true
     filters:
       filepath.regex: '(?i)dts[-. ]?x(?!\d)'
+
+# Match TrueHD Atmos, This one doesn't have a official image yet, so it will use the TrueHD one.
+  Dolby-TrueHD-Atmos:
+    template:
+      - name: AudioCodec
+        weight: 5000
+        slug: truehd-atmos
+    plex_all: true
+    filters:
+      audio_track_title.regex: '(?i)true[ .-]?hd[ .-]?atmos'
+
+  Dolby-TrueHD-Atmos-Filepath:
+    template:
+      - name: AudioCodec
+        overlay: Dolby-TrueHD-Atmos
+        weight: 5000
+        slug: truehd-atmos
+    plex_all: true
+    filters:
+      filepath.regex: '(?i)true[ .-]?hd[ .-]?atmos'


### PR DESCRIPTION
- Added: placeholder for missing audio codec without images yet
- Changed: scoring to match TRaSH Guides
- Fixed: regex to be more strict to get the correct audio matching

## Checklist

- [x] I only edited my own config files.
- [x] I didn't upload any poster or background images to the repository
