### PR TITLE
shared template order bugfix

### DIFF
--- a/PMM/templates.yml
+++ b/PMM/templates.yml
@@ -48,7 +48,7 @@ templates:
     item_radarr_tag: <<item_radarr_tag>>
     item_sonarr_tag: <<item_sonarr_tag>>
     collection_mode: <<collection_mode>>
-    sort_title: "!<<collection_section>><<pre>><<order_<<key>>>><<sort>>"
+    sort_title: "!<<collection_section>><<pre>><<order>><<key>><<sort>>"
 
   chart_shared:
     default:


### PR DESCRIPTION
Removed text that was inserting "<<order" into Universe collections.

## Checklist

- [ ] I only edited my own config files.
- [x] I didn't upload any poster or background images to the repository
