### PR TITLE
Update franchise.yml

### DIFF
--- a/PMM/movie/franchise.yml
+++ b/PMM/movie/franchise.yml
@@ -38,6 +38,9 @@ templates:
       - name_mapping
       - sort_title
       - build_collection
+      - radarr_folder
+      - radarr_tag
+      - item_radarr_tag
     cache_builders: 1
     minimum_items: <<minimum_items>>
     tmdb_collection_details: <<value>>


### PR DESCRIPTION
Adding to optional to fix an issue of <<item_radarr_tag>> being added as a tag to radarr

## Checklist

- [ ] I only edited my own config files.
- [ ] I didn't upload any poster or background images to the repository
