### PR TITLE
Fixed the default PMM ratings rating2 horizontal positioning.

### DIFF
--- a/PMM/overlays/ratings.yml
+++ b/PMM/overlays/ratings.yml
@@ -288,7 +288,8 @@ templates:
             rating3: none
             value: <<standard_offset>>
           - rating_alignment: horizontal
-            horizontal_position: right            rating1: none
+            horizontal_position: right
+            rating1: none
             value: <<h2_offset>>
           - rating_alignment: horizontal
             horizontal_position: right
@@ -303,7 +304,8 @@ templates:
             value: <<standard_offset>>
           - rating_alignment: horizontal
             horizontal_position: left
-            value: <<h2_offset>>      rating2_vertical_offset:
+            value: <<h2_offset>>
+      rating2_vertical_offset:
         default: <<standard_offset>>
         conditions:
           - rating_alignment: horizontal

--- a/PMM/overlays/ratings.yml
+++ b/PMM/overlays/ratings.yml
@@ -281,15 +281,14 @@ templates:
             value: -<<ch2_offset>>
           - rating_alignment: horizontal
             horizontal_position: center
-            value: -<<ch3_offset>>
+            value: -<<center_offset>>
           - rating_alignment: horizontal
             horizontal_position: right
             rating1: none
             rating3: none
             value: <<standard_offset>>
           - rating_alignment: horizontal
-            horizontal_position: right
-            rating1: none
+            horizontal_position: right            rating1: none
             value: <<h2_offset>>
           - rating_alignment: horizontal
             horizontal_position: right

--- a/PMM/overlays/ratings.yml
+++ b/PMM/overlays/ratings.yml
@@ -296,15 +296,14 @@ templates:
             value: <<h2_offset>>
           - rating_alignment: horizontal
             horizontal_position: right
-            value: <<h3_offset>>
+            value: <<h2_offset>>
           - rating_alignment: horizontal
             horizontal_position: left
             rating1: none
             value: <<standard_offset>>
           - rating_alignment: horizontal
             horizontal_position: left
-            value: <<h2_offset>>
-      rating2_vertical_offset:
+            value: <<h2_offset>>      rating2_vertical_offset:
         default: <<standard_offset>>
         conditions:
           - rating_alignment: horizontal


### PR DESCRIPTION
The official PMM ratings overlay had rating 2 position issues when positioning horizontally for center and right.

---

### For line 284 (horizontal_position: center):
Bad positioning for rating 2.
![center-bad](https://user-images.githubusercontent.com/428312/197417070-997478e8-14a2-4184-b24f-3bf264edb7ea.jpeg)

Fixed positioning for rating 2.
![center-fixed](https://user-images.githubusercontent.com/428312/197417078-66afa157-9630-4b1c-81bd-5f49842f280d.jpeg)

---
### For line 300 (horizontal_position: right):
Bad positioning for rating 2.
![right-bad](https://user-images.githubusercontent.com/428312/197417198-5964803a-a41e-43e0-80b1-4840486cf88d.jpeg)

Fixed positioning for rating 2.
![right-fixed](https://user-images.githubusercontent.com/428312/197417215-9c5efb62-6394-408d-b9b4-f95c9e5f8447.jpeg)

---

## Checklist

- [ ] I only edited my own config files.
- [x] I didn't upload any poster or background images to the repository
