### PR TITLE
Holiday movies based on keywords

### DIFF
--- a/SegueChris/Movies.yml
+++ b/SegueChris/Movies.yml
@@ -1,0 +1,16 @@
+templates:
+  Holiday:
+    summary: "Christmas is coming, countdown the nights with a collection of Christmas movies to get you into the festive mood."
+    tmdb_keyword: <<keyword>>
+    delete_not_scheduled: true
+    run_again: false
+    visible_home: true
+    visible_shared: true
+    sync_mode: sync
+
+collections:
+  Christmas Movies:
+    schedule: range(11/25-12/31)
+    sort_title: '!AB'
+    template: { name: Holiday, keyword: "207317, 65" }
+    collection_order: title.asc


### PR DESCRIPTION
Have not seen a holiday collection which is based on TMDB keywords. The existing method of IMDB lists works but relies on users modifying and expanding the lists as new holiday movies come out. This method should automatically expand as new titles are added and keywords filled in. 

=== Running Christmas Movies Collection ====
Builder: tmdb_keyword: 207317
Processing TMDb Keyword: (207317) christmas (2257 Movies)
2257 IDs Found
Builder: tmdb_keyword: 65
Processing TMDb Keyword: (65) holiday (843 Movies)
843 IDs Found

## Checklist

- [X] I only edited my own config files.
- [X] I didn't upload any poster or background images to the repository